### PR TITLE
export the dll and lib in msvc compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,18 +17,16 @@ include_directories(include)
 # Add the source files
 set(SOURCES src/thread_pool.cpp src/worker_thread.cpp)
 
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)
+
 # Generate the shared library
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-message("Use MSVC!")
-add_library(ThreadPool STATIC ${SOURCES})
+	message("Use MSVC!")
+	add_library(ThreadPool SHARED ${SOURCES})
 else()
-add_library(ThreadPool SHARED ${SOURCES})
+	add_library(ThreadPool SHARED ${SOURCES})
 endif()
-
-
-# Set the output directory for the library
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)
-set_target_properties(ThreadPool PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)
 
 add_executable(FunctionalTest tests/functional_test.cpp)
 add_executable(PerformanceTest tests/performance_test.cpp)
@@ -36,16 +34,43 @@ add_executable(PerformanceTest tests/performance_test.cpp)
 target_link_libraries(FunctionalTest PRIVATE ThreadPool)
 target_link_libraries(PerformanceTest PRIVATE ThreadPool)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+# if using CL compiler ,using test can't export the dll and exe in bin.
 # Set the output directory for the test executable
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
-set_target_properties(FunctionalTest PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
-set_target_properties(PerformanceTest PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+set_target_properties(ThreadPool PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin
+)
+set_target_properties(FunctionalTest PROPERTIES 
+RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+set_target_properties(PerformanceTest PROPERTIES 
+RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
 
-# Add the test executable
+else()
+
+set_target_properties(ThreadPool PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin
+)
+set_target_properties(FunctionalTest PROPERTIES 
+RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+set_target_properties(PerformanceTest PROPERTIES 
+RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)
+# Add the test executable to the list of tests
 
 add_test(NAME FunctionalTest COMMAND FunctionalTest)
 add_test(NAME PerformanceTest COMMAND PerformanceTest)
-
-# Add the test executable to the list of tests
-
 enable_testing()
+
+endif()
+
+
+
+
+
+
+
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,13 @@ include_directories(include)
 set(SOURCES src/thread_pool.cpp src/worker_thread.cpp)
 
 # Generate the shared library
+if(MSVC)
+message("Use MSVC!")
+add_library(ThreadPool STATIC ${SOURCES})
+else()
 add_library(ThreadPool SHARED ${SOURCES})
+endif()
+
 
 # Set the output directory for the library
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(include)
 set(SOURCES src/thread_pool.cpp src/worker_thread.cpp)
 
 # Generate the shared library
-if(MSVC)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 message("Use MSVC!")
 add_library(ThreadPool STATIC ${SOURCES})
 else()

--- a/include/thread_pool.hpp
+++ b/include/thread_pool.hpp
@@ -24,10 +24,12 @@
 #include <shared_mutex>
 #include <future>
 
-#ifndef DLL_EXPORT
-#define THREAD_EXPORT __declspec(dllexport)
-#else
-#define THREAD_EXPORT __declspec(dllimport)
+#ifdef _WIN32
+    #ifndef DLL_EXPORT
+        #define THREAD_EXPORT __declspec(dllexport)
+    #else
+        #define THREAD_EXPORT __declspec(dllimport)
+    #endif
 #endif
 
 /**
@@ -44,7 +46,11 @@ namespace thread_utils
  * The thread_pool class provides a simple interface for executing tasks concurrently using a pool of worker threads.
  * The class allows submitting tasks to the thread pool, pausing and resuming the pool, and shutting down the pool.
  */
+#ifdef _WIN32
 class THREAD_EXPORT thread_pool {
+#else
+class thread_pool {
+#endif
 private:
     class worker_thread;        // 工作线程类
     enum class status_t : std::int8_t { 

--- a/include/thread_pool.hpp
+++ b/include/thread_pool.hpp
@@ -24,6 +24,12 @@
 #include <shared_mutex>
 #include <future>
 
+#ifndef DLL_EXPORT
+#define THREAD_EXPORT __declspec(dllexport)
+#else
+#define THREAD_EXPORT __declspec(dllimport)
+#endif
+
 /**
  * @namespace thread_utils
  * @brief A namespace that contains classes and functions related to thread utilities.
@@ -38,7 +44,7 @@ namespace thread_utils
  * The thread_pool class provides a simple interface for executing tasks concurrently using a pool of worker threads.
  * The class allows submitting tasks to the thread pool, pausing and resuming the pool, and shutting down the pool.
  */
-class thread_pool {
+class THREAD_EXPORT thread_pool {
 private:
     class worker_thread;        // 工作线程类
     enum class status_t : std::int8_t { 


### PR DESCRIPTION
1. In msvc , need dllexport adn dllimport to export the *lib.
2. export the program,dll,lib in the same directory.